### PR TITLE
Removing extra network binding to localhost in docker-compose

### DIFF
--- a/example/apisix_conf/config.yaml
+++ b/example/apisix_conf/config.yaml
@@ -59,7 +59,7 @@ nginx_config:                     # config for render the template to genarate n
       - 'unix:'    
 
 etcd:
-  host: "http://127.0.0.1:2379"   # etcd address
+  host: "http://etcd:2379"   # etcd address
   prefix: "/apisix"               # apisix configurations prefix
   timeout: 1                      # 1 seconds
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro
     depends_on:
       - etcd
-    network_mode: host
 
   etcd:
     # if you are in the mainland China, please use Azure China mirror:
@@ -25,8 +24,6 @@ services:
       ETCD_DATA_DIR: /etcd_data
     ports:
       - "127.0.0.1:2379:2379/tcp"
-    networks:
-      - apisix
 
   web1:
     image: ruby:2-alpine
@@ -34,8 +31,6 @@ services:
     restart: always
     ports:
       - "127.0.0.1:9081:8000/tcp"
-    networks:
-      - apisix
 
   web2:
     image: ruby:2-alpine
@@ -43,9 +38,3 @@ services:
     restart: always
     ports:
       - "127.0.0.1:9082:8000/tcp"
-    networks:
-      - apisix
-
-networks:
-  apisix:
-    driver: bridge


### PR DESCRIPTION
It's unnecessary to bind to localhost and create an additional network. 
By specifying the following in the apisix_conf we can avoid additional configurations
```
etcd:
  host: "http://etcd:2379"   # etcd address
```
The following shows the example, working with the aforementioned configurations.
![image](https://user-images.githubusercontent.com/13045528/80967590-eaec4980-8e16-11ea-8e47-889bf64ff4ab.png)

